### PR TITLE
modelsのviewに関する処理をきれいに修正

### DIFF
--- a/face_auth/recognizer/serializers/models_serializers.py
+++ b/face_auth/recognizer/serializers/models_serializers.py
@@ -1,33 +1,45 @@
 from rest_framework import serializers
-from ..models import TrainingGroup, TrainingData, FeatureData
+from ..models import TrainingGroup, TrainingData
+from ..services.validations import is_exist_face
+from ..services.tools import open_image
+
 
 class TrainingGroupSerializer(serializers.ModelSerializer):
     class Meta:
         model = TrainingGroup
-        fields = ['id', 'name', 'owner', 'created_at', 'updated_at']  # 必要なフィールドを指定
-        read_only_fields = ['id', 'created_at', 'updated_at']  # 自動的に生成されるフィールドを読み取り専用にする
+        fields = ['id', 'name', 'owner', 'created_at', 'updated_at']
+        read_only_fields = ['id', 'owner', 'created_at', 'updated_at']
 
-        def update(self, instance, validated_data):
-            # ownerの更新を無効にするため、validated_dataからownerを削除
-            validated_data.pop('owner', None)  # ownerが含まれていても無視
-            return super().update(instance, validated_data)
-        
+    def update(self, instance, validated_data):
+        # nameは必須
+        if "name" not in validated_data:
+            raise serializers.ValidationError("detail: 'name' is required")
+        return super().update(instance, validated_data)
+
 
 class TrainingDataSerializer(serializers.ModelSerializer):
     class Meta:
         model = TrainingData
         fields = ['id', 'group', 'image', 'label', 'created_at', 'updated_at']
-        read_only_fields = ['id', 'created_at', 'updated_at']
+        read_only_fields = ['id', 'group', 'created_at', 'updated_at']
 
-        def update(self, instance, validated_data):
-            # groupの更新を無効にするため、validated_dataからgroupを削除
-            validated_data.pop('group', None)  # groupが含まれていても無視
-            return super().update(instance, validated_data)
-        
+    def create(self, validated_data):
+        # imageに顔が見つからない場合はエラー
+        image = open_image(validated_data.pop('image'))
+        if not is_exist_face(image):
+            raise serializers.ValidationError("detail: cannot detect face in image")
+        return super().create(validated_data)
 
-class FeatureDataSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = FeatureData
-        fields = ['id', 'group', 'feature', 'created_at', 'updated_at']
-        read_only_fields = ['id', 'created_at', 'updated_at']
+    def update(self, instance, validated_data):
+        # imageとlabelのどちらもない場合はエラー
+        if "image" not in validated_data and "label" not in validated_data:
+            raise serializers.ValidationError("detail: either 'image' or 'label' must be provided")
         
+        # imageに顔が見つからない場合はエラー
+        if "image" in validated_data:
+            image = open_image(validated_data["image"])
+            if not is_exist_face(image):
+                raise serializers.ValidationError("detail: cannot detect face in image")
+        
+        return super().update(instance, validated_data)
+    

--- a/face_auth/recognizer/urls.py
+++ b/face_auth/recognizer/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views.models_views import TrainingGroupViewSet, TrainingDataViewSet
+from .views.models_views import TrainingGroupViewSet, TrainingDataViewSet, GroupDataViewSet
 from .views.recognize_views import TrainView, PredictView
 
 training_group_list = TrainingGroupViewSet.as_view({
@@ -8,26 +8,27 @@ training_group_list = TrainingGroupViewSet.as_view({
 })
 
 training_group_detail = TrainingGroupViewSet.as_view({
-    'get': 'retrieve',   # GET: /training-groups/<uuid:pk>/ - 特定のTrainingGroupのTrainingData一覧
+    'get': 'retrieve',   # GET: /training-groups/<uuid:pk>/ - 特定のTrainingGroup取得
     'patch': 'update',   # PATCH: /training-groups/<uuid:pk>/ - TrainingGroup更新
     'delete': 'destroy', # DELETE: /training-groups/<uuid:pk>/ - TrainingGroup削除
 })
 
 training_data_detail = TrainingDataViewSet.as_view({
-    'get': 'retrieve',   # GET: /training-data/<uuid:pk>/ - 特定のTrainingData
+    'get': 'retrieve',   # GET: /training-data/<uuid:pk>/ - 特定のTrainingData取得
     'patch': 'update',   # PATCH: /training-data/<uuid:pk>/ - TrainingData更新
     'delete': 'destroy', # DELETE: /training-data/<uuid:pk>/ - TrainingData削除
 })
 
-training_data_create = TrainingDataViewSet.as_view({
-    'post': 'create',    # POST: /training-data/<uuid:group_pk>/ - TrainingData作成
+group_data_list_create = GroupDataViewSet.as_view({
+    'get': 'list_images',   # GET: /training-groups/<uuid:group_pk>/images/ - グループごとの画像一覧
+    'post': 'create_image', # POST: /training-groups/<uuid:group_pk>/images/ - グループに画像追加
 })
 
 urlpatterns = [
-    path('training-groups/', training_group_list, name='training-group-list'),                  # GET, POST
-    path('training-groups/<uuid:pk>/', training_group_detail, name='training-group-detail'),    # GET, PATCH, DELETE
-    path('training-data/<uuid:pk>/', training_data_detail, name='training-data-detail'),        # GET, PATCH, DELETE
-    path('training-data/<uuid:group_pk>/', training_data_create, name='training-data-create'),  # POST
-    path('train/<uuid:pk>/', TrainView.as_view(), name='train'),
-    path('predict/<uuid:pk>/', PredictView.as_view(), name='predict'),                          # POST
+    path('training-groups/', training_group_list, name='training-group-list'),                   # GET, POST
+    path('training-groups/<uuid:pk>/', training_group_detail, name='training-group-detail'),     # GET, PATCH, DELETE
+    path('training-data/<uuid:pk>/', training_data_detail, name='training-data-detail'),         # GET, PATCH, DELETE
+    path('training-groups/<uuid:group_pk>/images/', group_data_list_create, name='group-data'),  # GET, POST for images in group
+    path('train/<uuid:pk>/', TrainView.as_view(), name='train'),                                 # Train model
+    path('predict/<uuid:pk>/', PredictView.as_view(), name='predict'),                           # Predict with model
 ]

--- a/face_auth/recognizer/views/models_views.py
+++ b/face_auth/recognizer/views/models_views.py
@@ -1,167 +1,104 @@
 from rest_framework import viewsets, status
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.decorators import action
 from ..models import TrainingGroup, TrainingData
-from ..serializers.models_serializers import TrainingGroupSerializer, TrainingDataSerializer
-from ..services.validations import is_exist_face
-from ..services.tools import open_image
+from ..serializers import TrainingGroupSerializer, TrainingDataSerializer
+from django.shortcuts import get_object_or_404
+
 
 class TrainingGroupViewSet(viewsets.ViewSet):
-    # 認証済みのユーザーのみアクセス可能
     permission_classes = [IsAuthenticated]
 
+    # すべてのグループを取得
     def list(self, request):
-        """
-        現在のユーザーがオーナーのTrainingGroupをリストとして返す
-        """
-        queryset = TrainingGroup.objects.filter(owner=self.request.user)
-        serializer = TrainingGroupSerializer(queryset, many=True)
+        groups = TrainingGroup.objects.filter(owner=request.user)
+        serializer = TrainingGroupSerializer(groups, many=True)
         return Response(serializer.data)
 
+    # 特定のグループを取得
     def retrieve(self, request, pk=None):
-        """
-        特定のTrainingGroupのTrainingDataを取得
-        グループのオーナーが現在のユーザーでない場合は404エラー
-        """
-        try:
-            instance = TrainingData.objects.get(group__id=pk, group__owner=self.request.user)
-            serializer = TrainingDataSerializer(instance)
-            return Response(serializer.data)
-        except TrainingData.DoesNotExist:
-            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
-
-
-    def create(self, request):
-        """
-        新しいTrainingGroupを作成し、オーナーを現在のユーザーに設定
-        """
-        serializer = TrainingGroupSerializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        serializer.save(owner=request.user)  # オーナーを設定して保存
-        return Response(serializer.data, status=status.HTTP_201_CREATED)
-
-    def update(self, request, pk=None):
-        """
-        TrainingGroupの更新処理
-        PATCHメソッドの場合は部分更新
-        """
-        partial = request.method == 'PATCH'
-        instance = self.get_object(pk)
-
-        # 現在のユーザーがオーナーでない場合、403エラー
-        if instance.owner != request.user:
-            return Response({"detail": "You do not have permission to edit this group."}, status=status.HTTP_403_FORBIDDEN)
-
-        serializer = TrainingGroupSerializer(instance, data=request.data, partial=partial)
-        serializer.is_valid(raise_exception=True)
-        serializer.save()
+        group = get_object_or_404(TrainingGroup, pk=pk, owner=request.user)
+        serializer = TrainingGroupSerializer(group)
         return Response(serializer.data)
 
+    # 新しいグループを追加
+    def create(self, request):
+        serializer = TrainingGroupSerializer(data=request.data)
+        if serializer.is_valid():
+            serializer.save(owner=request.user)
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    # グループ名を変更（他の項目は変更不可）
+    def update(self, request, pk=None):
+        group = get_object_or_404(TrainingGroup, pk=pk, owner=request.user)
+        serializer = TrainingGroupSerializer(group, data=request.data, partial=True)
+        if serializer.is_valid():
+            group.name = serializer.validated_data["name"]
+            group.save()
+            return Response(TrainingGroupSerializer(group).data)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    # グループを削除
     def destroy(self, request, pk=None):
-        """
-        TrainingGroupの削除処理
-        現在のユーザーがオーナーでない場合、403エラー
-        """
-        instance = self.get_object(pk)
-        if instance.owner != request.user:
-            return Response({"detail": "You do not have permission to delete this group."}, status=status.HTTP_403_FORBIDDEN)
-
-        instance.delete()
+        group = get_object_or_404(TrainingGroup, pk=pk, owner=request.user)
+        group.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
-
-    def get_object(self, pk):
-        """
-        特定のTrainingGroupを取得
-        存在しない場合やオーナーが異なる場合は404エラー
-        """
-        try:
-            return TrainingGroup.objects.get(pk=pk, owner=self.request.user)
-        except TrainingGroup.DoesNotExist:
-            raise Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
 
 
 class TrainingDataViewSet(viewsets.ViewSet):
-    # 認証済みのユーザーのみアクセス可能
     permission_classes = [IsAuthenticated]
 
+    # すべての画像データを取得
     def list(self, request):
-        """
-        listメソッドはサポートされないため405エラーを返す
-        """
-        return Response(status=status.HTTP_405_METHOD_NOT_ALLOWED)
-
-    def retrieve(self, request, pk=None):
-        """
-        特定のTrainingDataを取得
-        グループのオーナーが現在のユーザーでない場合は404エラー
-        """
-        try:
-            instance = TrainingData.objects.get(id=pk, group__owner=self.request.user)
-            serializer = TrainingDataSerializer(instance)
-            return Response(serializer.data)
-        except TrainingData.DoesNotExist:
-            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
-
-    def create(self, request,group_pk=None):
-        """
-        新しいTrainingDataを作成
-        グループのオーナーが現在のユーザーでない場合は403エラー
-        """
-        serializer = TrainingDataSerializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-
-        # グループのオーナーが現在のユーザーか確認
-        group = TrainingGroup.objects.get(pk=group_pk)
-        if group.owner != request.user:
-            return Response({"detail": "You do not have permission to create training data for this group."}, status=status.HTTP_403_FORBIDDEN)
-
-        # 顔を検出していない場合は404エラー
-        if not is_exist_face(open_image(request.data['image'])):
-            return Response({"detail": "Face not found."}, status=status.HTTP_404_NOT_FOUND)
-
-        serializer.save()
-        return Response(serializer.data, status=status.HTTP_201_CREATED)
-
-    def update(self, request, pk=None):
-        """
-        TrainingDataの更新処理
-        PATCHメソッドの場合は部分更新
-        """
-        partial = request.method == 'PATCH'
-        instance = self.get_object(pk)
-
-        # グループのオーナーが現在のユーザーでない場合は403エラー
-        if instance.group.owner != request.user:
-            return Response({"detail": "You do not have permission to edit this training data."}, status=status.HTTP_403_FORBIDDEN)
-
-        serializer = TrainingDataSerializer(instance, data=request.data, partial=partial)
-        serializer.is_valid(raise_exception=True)
-        
-        # 顔を検出していない場合は404エラー
-        if not is_exist_face(open_image(instance.image)):
-            return Response({"detail": "Face not found."}, status=status.HTTP_404_NOT_FOUND)
-        
-        serializer.save()
+        data = TrainingData.objects.filter(group__owner=request.user)
+        serializer = TrainingDataSerializer(data, many=True)
         return Response(serializer.data)
 
-    def destroy(self, request, pk=None):
-        """
-        TrainingDataの削除処理
-        グループのオーナーが現在のユーザーでない場合は403エラー
-        """
-        instance = self.get_object(pk)
-        if instance.group.owner != request.user:
-            return Response({"detail": "You do not have permission to delete this training data."}, status=status.HTTP_403_FORBIDDEN)
+    # 特定の画像データを取得
+    def retrieve(self, request, pk=None):
+        data = get_object_or_404(TrainingData, pk=pk, group__owner=request.user)
+        serializer = TrainingDataSerializer(data)
+        return Response(serializer.data)
 
-        instance.delete()
+    # 画像とラベル名を変更（他の項目は変更不可）
+    def update(self, request, pk=None):
+        data = get_object_or_404(TrainingData, pk=pk, group__owner=request.user)
+        serializer = TrainingDataSerializer(data, data=request.data, partial=True)
+        if serializer.is_valid():
+            if "image" in serializer.validated_data:
+                data.image = serializer.validated_data["image"]
+            if "label" in serializer.validated_data:
+                data.label = serializer.validated_data["label"]
+            data.save()
+            return Response(TrainingDataSerializer(data).data)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    # 特定の画像を削除
+    def destroy(self, request, pk=None):
+        data = get_object_or_404(TrainingData, pk=pk, group__owner=request.user)
+        data.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
-    def get_object(self, pk):
-        """
-        特定のTrainingDataを取得
-        存在しない場合やオーナーが異なる場合は404エラー
-        """
-        try:
-            return TrainingData.objects.get(pk=pk, group__owner=self.request.user)
-        except TrainingData.DoesNotExist:
-            raise Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+
+class GroupDataViewSet(viewsets.ViewSet):
+    permission_classes = [IsAuthenticated]
+
+    # 特定のグループのすべての画像を取得
+    @action(detail=True, methods=["get"], url_path="images")
+    def list_images(self, request, group_pk=None):
+        group = get_object_or_404(TrainingGroup, pk=group_pk, owner=request.user)
+        images = TrainingData.objects.filter(group=group)
+        serializer = TrainingDataSerializer(images, many=True)
+        return Response(serializer.data)
+
+    # 特定のグループに画像を追加
+    @action(detail=True, methods=["post"], url_path="images")
+    def create_image(self, request, group_pk=None):
+        group = get_object_or_404(TrainingGroup, pk=group_pk, owner=request.user)
+        serializer = TrainingDataSerializer(data=request.data)
+        if serializer.is_valid():
+            serializer.save(group=group)
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
- 処理を切り分けるために、グループidを使用したTrainDataの処理を新規クラスに定義
- 不要な通信はviewでオーバーライドして無効にするのではなく、urlsで設定しないことで無効に変更
- view行っていたバリデーションをserializersに移動
- オーナーのチェックをfilterに組み込むことで不要にする